### PR TITLE
fix: resolve resource leakage in BiampTesiraConnection.close() method

### DIFF
--- a/src/tesira.py
+++ b/src/tesira.py
@@ -329,6 +329,19 @@ class BiampTesiraConnection:
     async def close(self) -> None:
         """Close all telnet connections."""
         if self._subscription_telnet is not None:
-            self._subscription_telnet.close()
+            try:
+                self._subscription_telnet.close()
+                _LOGGER.debug("Subscription telnet connection closed")
+            except (OSError, RuntimeError):
+                _LOGGER.exception("Error closing subscription telnet connection")
+            finally:
+                self._subscription_telnet = None
+
         if self._command_telnet is not None:
-            self._command_telnet.close()
+            try:
+                self._command_telnet.close()
+                _LOGGER.debug("Command telnet connection closed")
+            except (OSError, RuntimeError):
+                _LOGGER.exception("Error closing command telnet connection")
+            finally:
+                self._command_telnet = None


### PR DESCRIPTION
- Set connection references to None after closing to prevent resource leaks
- Add comprehensive error handling for OSError and RuntimeError during closure
- Add debug logging for successful closures and exception logging for failures
- Ensure cleanup happens in finally blocks to guarantee resource cleanup

The fix ensures that _subscription_telnet and _command_telnet are properly
set to None after calling close(), allowing proper garbage collection and
preventing memory leaks from lingering connection references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown handling to prevent errors during disconnects, reducing the chance of crashes or unhandled exceptions.
  * Ensures clean teardown of command and subscription connections even when underlying network issues occur.
  * Adds more robust error handling and cleanup to improve overall stability during stop/restart scenarios.
  * Enhances diagnostic logging around connection closure to aid troubleshooting without impacting normal usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->