### PR TITLE
feat: add automatic version bumping with bump-my-version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,10 @@
+[tool.bumpversion]
+current_version = "1.1.0"
+commit = true
+tag = false
+message = "auto: bump version to {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "src/_version.py"
+search = "__version_info__ = ({major}, {minor}, {patch})"
+replace = "__version_info__ = ({new_major}, {new_minor}, {new_patch})"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Bump version and commit (only for pushes to main)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'auto:')
         id: bump
-        uses: callowayproject/bump-my-version@master
+        uses: callowayproject/bump-my-version@v1.2.3
         env:
           BUMPVERSION_TAG: "false"
         with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
       attestations: write
       id-token: write
@@ -27,6 +27,24 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump version and commit (only for pushes to main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'auto:')
+        id: bump
+        uses: callowayproject/bump-my-version@master
+        env:
+          BUMPVERSION_TAG: "false"
+        with:
+          args: patch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check version bump
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          echo "Version was bumped from ${{ steps.bump.outputs.previous-version }} to ${{ steps.bump.outputs.current-version }}!"
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
- Add bump-my-version GitHub Action for automatic patch version increments
- Configure .bumpversion.toml to update src/_version.py automatically
- Use 'auto:' prefix in commit messages to prevent infinite loops
- Update workflow permissions to allow writing to repository
- Version bumps only trigger on pushes to main branch (not PRs or tags)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced automated version bumping in CI: increments patch versions, commits changes, and skips tagging.
  - Enhanced workflow to bump version only on pushes to main (excluding commits starting with “auto:”) and report previous/current versions.
  - Increased GitHub Actions permissions and explicitly pass the repository token to improve reliability.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->